### PR TITLE
3: Enforce SSL Connection for heroku deployment

### DIFF
--- a/backend/src/party/presenters/rest/index.ts
+++ b/backend/src/party/presenters/rest/index.ts
@@ -3,6 +3,7 @@ import http from 'http'
 import express from 'express'
 import cors from 'cors'
 import morgan from 'morgan'
+import sslRedirect from 'heroku-ssl-redirect'
 
 import config from '@common/config'
 import { apiV1 } from './controllers/v1'
@@ -14,6 +15,7 @@ const logger = morgan('combined')
 const app = express()
 app.use(logger)
 app.use(cors())
+app.use(sslRedirect())
 
 app.use(express.static(path.join(__dirname, './client/build')))
 

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "cors": "^2.8.5",
     "dotenv": "^8.2.0",
     "express": "^4.17.1",
+    "heroku-ssl-redirect": "^0.0.4",
     "ioredis": "^4.14.1",
     "knex": "^0.20.8",
     "morgan": "^1.9.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2335,6 +2335,11 @@ hash.js@^1.0.0, hash.js@^1.0.3:
     inherits "^2.0.3"
     minimalistic-assert "^1.0.1"
 
+heroku-ssl-redirect@^0.0.4:
+  version "0.0.4"
+  resolved "https://registry.yarnpkg.com/heroku-ssl-redirect/-/heroku-ssl-redirect-0.0.4.tgz#21ba0707aa503b50a412a0946abfaa88ef7d082c"
+  integrity sha1-IboHB6pQO1CkEqCUar+qiO99CCw=
+
 hmac-drbg@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/hmac-drbg/-/hmac-drbg-1.0.1.tgz#d2745701025a6c775a6c545793ed502fc0c649a1"


### PR DESCRIPTION
- Add heroku-ssl-redirect package
- Register Express middleware